### PR TITLE
Update to include portaudiolibrary.

### DIFF
--- a/README
+++ b/README
@@ -30,6 +30,17 @@ and unpack all these files into the buildwin directory as the compile is depende
 
 For Mingw, only a single file "libcurl.dll" is needed for libcurl, for visual studio, several files.
 
+
+OSX Specific Libraries
+==========================
+The OS X compilation is dependent on these files 
+
+Under OS X the port audio library is needed.
+There is a zip file containing header and library files:
+http://sourceforge.net/projects/opencpnplugins/files/weatherfax_pi/OSXportaudiofiles.zip/download
+Download this file and unzip it in the /usr/local directory as the compile is dependent on these.
+The make create-pkg command will include the library in the package.
+
 License
 =======
 The plugin code is licensed under the terms of the GPL v3+

--- a/buildosx/InstallOSX/weatherfax_pi.pkgproj.in
+++ b/buildosx/InstallOSX/weatherfax_pi.pkgproj.in
@@ -8,7 +8,7 @@
 			<key>PACKAGE_FILES</key>
 			<dict>
 				<key>DEFAULT_INSTALL_LOCATION</key>
-				<string>/Applications/OpenCPN.app/Contents</string>
+				<string>/</string>
 				<key>HIERARCHY</key>
 				<dict>
 					<key>CHILDREN</key>
@@ -601,6 +601,73 @@
 							<key>UID</key>
 							<integer>0</integer>
 						</dict>
+						<dict>
+							<key>CHILDREN</key>
+							<array>
+								<dict>
+									<key>CHILDREN</key>
+									<array>
+										<dict>
+											<key>CHILDREN</key>
+											<array>
+												<dict>
+													<key>CHILDREN</key>
+													<array/>
+													<key>GID</key>
+													<integer>80</integer>
+													<key>PATH</key>
+													<string>/usr/local/lib/libportaudio.2.dylib</string>
+													<key>PATH_TYPE</key>
+													<integer>0</integer>
+													<key>PERMISSIONS</key>
+													<integer>493</integer>
+													<key>TYPE</key>
+													<integer>3</integer>
+													<key>UID</key>
+													<integer>0</integer>
+												</dict>
+											</array>
+											<key>GID</key>
+											<integer>80</integer>
+											<key>PATH</key>
+											<string>lib</string>
+											<key>PATH_TYPE</key>
+											<integer>0</integer>
+											<key>PERMISSIONS</key>
+											<integer>493</integer>
+											<key>TYPE</key>
+											<integer>2</integer>
+											<key>UID</key>
+											<integer>0</integer>
+										</dict>
+									</array>
+									<key>GID</key>
+									<integer>80</integer>
+									<key>PATH</key>
+									<string>local</string>
+									<key>PATH_TYPE</key>
+									<integer>0</integer>
+									<key>PERMISSIONS</key>
+									<integer>493</integer>
+									<key>TYPE</key>
+									<integer>2</integer>
+									<key>UID</key>
+									<integer>0</integer>
+								</dict>
+							</array>
+							<key>GID</key>
+							<integer>80</integer>
+							<key>PATH</key>
+							<string>usr</string>
+							<key>PATH_TYPE</key>
+							<integer>0</integer>
+							<key>PERMISSIONS</key>
+							<integer>493</integer>
+							<key>TYPE</key>
+							<integer>2</integer>
+							<key>UID</key>
+							<integer>0</integer>
+						</dict>
 					</array>
 					<key>GID</key>
 					<integer>0</integer>
@@ -681,15 +748,15 @@
 				<integer>4</integer>
 				<key>BACKGROUND_PATH</key>
 				<dict>
-                                        <key>PATH</key>
-                                        <string>pkg_background.jpg</string>
-                                        <key>PATH_TYPE</key>
-                                        <integer>1</integer>
-                                </dict>
-                                <key>CUSTOM</key>
-                                <integer>1</integer>
-                                <key>SCALING</key>
-                                <integer>1</integer>
+					<key>PATH</key>
+					<string>pkg_background.jpg</string>
+					<key>PATH_TYPE</key>
+					<integer>1</integer>
+				</dict>
+				<key>CUSTOM</key>
+				<integer>1</integer>
+				<key>SCALING</key>
+				<integer>1</integer>
 			</dict>
 			<key>INSTALLATION TYPE</key>
 			<dict>
@@ -1373,7 +1440,7 @@ chk_flag = (ocpn_vers &gt;= '3.3.1606'); }
 // return the check results
   return chk_flag;
   }
-  </string>
+</string>
 	</dict>
 	<key>TYPE</key>
 	<integer>0</integer>


### PR DESCRIPTION
Added the OS X 10.7 library files to source forge for download.
See README file for details.
The library files should be in /usr/local/lib and /usr/local/include for the compile.
The make create-pkg command will add the library to the package.