### PR TITLE
Use only the plugin translations, ignore the core OpenCPN ones.

### DIFF
--- a/WeatherFax.fbp
+++ b/WeatherFax.fbp
@@ -2,7 +2,7 @@
 <wxFormBuilder_Project>
     <FileVersion major="1" minor="13" />
     <object class="Project" expanded="1">
-        <property name="class_decoration"></property>
+        <property name="class_decoration">; wxWTranslateCatalog.h</property>
         <property name="code_generation">C++</property>
         <property name="disconnect_events">1</property>
         <property name="disconnect_mode">source_name</property>

--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -16,6 +16,7 @@ ENDIF (COMMAND cmake_policy)
 MESSAGE (STATUS "*** Staging to build ${PACKAGE_NAME} ***")
 
 configure_file(cmake/version.h.in ${PROJECT_SOURCE_DIR}/src/version.h)
+configure_file(cmake/wxWTranslateCatalog.h.in ${PROJECT_SOURCE_DIR}/src/wxWTranslateCatalog.h)
 SET(PACKAGE_VERSION "${PLUGIN_VERSION_MAJOR}.${PLUGIN_VERSION_MINOR}" )
 
 #SET(CMAKE_BUILD_TYPE Debug)

--- a/cmake/wxWTranslateCatalog.h.in
+++ b/cmake/wxWTranslateCatalog.h.in
@@ -1,0 +1,42 @@
+/******************************************************************************
+ * $Id: ocpn_draw_pi.h,v 1.0 2015/01/28 01:54:37 jongough Exp $
+ *
+ * Project:  OpenCPN
+ * Purpose:  Redefine _() macro to allow usage of catalog
+ * Author:   Jon Gough
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register   *
+ *   $EMAIL$   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.             *
+ ***************************************************************************
+ */
+#ifndef _ODCATTRANS_H_
+#define _ODCATTRANS_H_
+
+#ifndef WXINTL_NO_GETTEXT_MACRO
+#ifdef _
+#undef _
+#endif // _
+#if wxCHECK_VERSION(3,0,0)
+#define _(s) wxGetTranslation((s), wxS("opencpn-${PROJECT_NAME}"))
+#else // wxCHECK_VERSION(3,0,0)
+    #define _(s) wxGetTranslation(wxT(s), wxT("opencpn-${PROJECT_NAME}"))
+#endif // wxCHECK_VERSION(3,0,0)
+#endif // WXINTL_NO_GETTEXT_MACRO
+
+#endif

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,2 @@
 version.h
+wxWTranslateCatalog.h

--- a/src/WeatherFaxUI.cpp
+++ b/src/WeatherFaxUI.cpp
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  3 2017)
+// C++ code generated with wxFormBuilder (version Dec 20 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #include "WeatherFaxUI.h"

--- a/src/WeatherFaxUI.h
+++ b/src/WeatherFaxUI.h
@@ -1,8 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Oct  3 2017)
+// C++ code generated with wxFormBuilder (version Dec 20 2017)
 // http://www.wxformbuilder.org/
 //
-// PLEASE DO "NOT" EDIT THIS FILE!
+// PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
 
 #ifndef __WEATHERFAXUI_H__
@@ -45,6 +45,8 @@
 #include <wx/dynarray.h>
 WX_DEFINE_ARRAY_PTR( wxWizardPageSimple*, WizardPages );
 #include <wx/choicebk.h>
+
+#include "wxWTranslateCatalog.h"
 
 ///////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This is to avoid confusion with other translations present in OpenCPN core.
This fixes a few issues with French translations, hopefully it won't cause
too much harm for the other languages.