### PR TITLE
Add back line 93 for wxWTranslateCatalog.h so that wxfax will compile for Windows

### DIFF
--- a/cmake/PluginConfigure.cmake
+++ b/cmake/PluginConfigure.cmake
@@ -90,6 +90,7 @@ include  ("VERSION.cmake")
 #  thereby allowing building from a read-only source tree.
 IF(NOT SKIP_VERSION_CONFIG)
     configure_file(${PROJECT_SOURCE_DIR}/cmake/version.h.in ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include/version.h)
+    configure_file(cmake/wxWTranslateCatalog.h.in ${PROJECT_SOURCE_DIR}/src/wxWTranslateCatalog.h)
     INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/include)
 ENDIF(NOT SKIP_VERSION_CONFIG)
 


### PR DESCRIPTION
It does compile now. Don't know what this change does to the Android version.