### PR TITLE
ov42 Branch for Opencpn 4.2-4.8.8   Completes. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,9 @@
 language: cpp
-
-matrix:
-  include:
-    - dist: trusty
-      compiler: gcc
-    - os: osx
-      compiler: clang
-
 install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; 
-      then
-         sudo apt-get -qq update;
-         sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev; 
-         sudo apt-get install libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev librtlsdr-dev;
-         sudo apt-get install rpm;
-      fi
-
-#    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install wxmac --devel; fi
-# We do not use wxmac, everything comes in the prebuilt tarball downloaded bellow
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; 
-      then
-          brew install cairo libexif libarchive portaudio;
-          wget http://opencpn.navnux.org/build_deps/cairo_macos107.tar.xz;
-          tar xJf cairo_macos107.tar.xz -C /tmp;
-          wget http://opencpn.navnux.org/build_deps/wx_opencpn_macos107.tar.xz;
-          tar xJf wx_opencpn_macos107.tar.xz -C /tmp;
-          wget http://opencpn.navnux.org/build_deps/libarchive_macos107.tar.xz;
-          tar xJf libarchive_macos107.tar.xz -C /tmp;
-          export PATH="/usr/local/opt/gettext/bin:$PATH";
-          echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile;
-          wget http://s.sudre.free.fr/Software/files/Packages.dmg;
-          hdiutil attach Packages.dmg;
-          sudo installer -pkg "/Volumes/Packages 1.2.4/Install Packages.pkg" -target "/";
-      fi
-# We install cairo and libarchive from Homebrew to pull in the dependencies, but use the custom Lion compatible build later.
-
+    - sudo apt-get -qq update
+    - sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev 
+    - sudo apt-get install libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev librtlsdr-dev
+    - sudo apt-get install rpm
 script:
   - if [[ "${COVERITY_SCAN_BRANCH}" == 1 ]];
     then
@@ -42,24 +11,8 @@ script:
       exit 0;
     fi
   - mkdir build && cd build
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; 
-    then
-       cmake -DCMAKE_BUILD_TYPE=Release ../;
-       make -sj2 package;
-    fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
-    then
-        cmake -DOCPN_USE_LIBCPP=ON -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx_opencpn_macos107/bin/wx-config -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx_opencpn_macos107" -DLibArchive_INCLUDE_DIR=/tmp/libarchive_macos107/include -DLibArchive_LIBRARY=/tmp/libarchive_macos107/lib/libarchive.dylib -DCAIRO_INCLUDE_DIR=/tmp/cairo_macos107/include -DCAIRO_LIBRARY=/tmp/cairo_macos107/lib/libcairo.dylib -DCMAKE_INSTALL_PREFIX=/tmp/opencpn ..;
-        make -s;
-        mkdir -p /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; 
-        chmod 644 /usr/local/lib/lib*.dylib;
-        cp /usr/local/lib/libportaudio.2.dylib .;
-        cp /tmp/libarchive_macos107/lib/libarchive.16.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; 
-        cp /tmp/cairo_macos107/lib/libcairo.2.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; 
-        make install; 
-#       librtlsdr.0.dylib still missing
-        #make create-pkg;
-     fi
+  - cmake -DCMAKE_BUILD_TYPE=Release ../
+  - make -j2 package
 
 notifications:
     email: false


### PR DESCRIPTION
I have an ov42 branch for the Opencpn 4.2 to 4.8.8 version.
This compiles with appveyor and .travis.   
Close it if you wish.