### PR TITLE
src: Use the native apple gl.h header.

### DIFF
--- a/src/WeatherFaxImage.cpp
+++ b/src/WeatherFaxImage.cpp
@@ -35,6 +35,8 @@
 #include "GL/gl_private.h"
 #include "GLES2/gl2.h"
 #include <qdebug.h>
+#elif defined(__APPLE__)
+#include <OpenGL/gl.h>
 #else
 #include <GL/gl.h>
 #endif


### PR DESCRIPTION
The gl.h header is available in all MacOs versions. Since the opengl
headers are designed to be adapted by the OS vendor, they actually do
differ on different platforms. For this reason, using the version
provided by the OS, here MacOS, should be preferred if available.

Adjust the include path on MacOS to the location where gl.h et. al.
lives.

The patch makes it possible to build against MacOS without using any bundled
OpenGL headers.